### PR TITLE
Check existence of custom element before defining wc-datetime

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -101,7 +101,8 @@ class RahuiWidget {
      * Setup date picker using wc-datepicker
      * https://sqrrl.github.io/wc-datepicker/
      */
-    customElements.define("wc-datepicker", WcDatepicker);
+    customElements.get("wc-datepicker") ||
+      customElements.define("wc-datepicker", WcDatepicker);
     const datepicker = document.getElementById(this.datePickerId) as Datepicker;
     if (datepicker) {
       // Disable dates before today


### PR DESCRIPTION
# Changes

Attempted fix for following exception:

<img width="1469" alt="image" src="https://github.com/user-attachments/assets/606dabd3-c8be-415f-b57b-9e64c260c5be">
